### PR TITLE
修复发音图标和无法发音的问题

### DIFF
--- a/bingdict.py
+++ b/bingdict.py
@@ -23,12 +23,26 @@ HTML_TMPL = """
 
 <script type="text/javascript" nonce="">
 //<![CDATA[
-var ClientAudioPlayer = {
-    Play: function(audioUrl) {
-        var audio = new Audio(audioUrl);
-        audio.play();
-    }
-};
+var ClientAudioPlayer = (function() {
+    var audioInstance = null;
+
+    return {
+        Play: function(audioUrl) {
+            // 如果已经存在音频实例，则暂停并重置
+            if (audioInstance) {
+                audioInstance.pause();
+                audioInstance.currentTime = 0;
+            } else {
+                // 否则，创建新的音频实例
+                audioInstance = new Audio();
+            }
+
+            // 设置新的音频文件URL并播放
+            audioInstance.src = audioUrl;
+            audioInstance.play();
+        }
+    };
+})();
 
 var ClientPartCall = {
   // 定义IAddInstrumentation方法

--- a/bingdict.py
+++ b/bingdict.py
@@ -20,10 +20,29 @@ HTML_TMPL = """
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
+
+<script type="text/javascript" nonce="">
+//<![CDATA[
+var ClientAudioPlayer = {
+    Play: function(audioUrl) {
+        var audio = new Audio(audioUrl);
+        audio.play();
+    }
+};
+
+var ClientPartCall = {
+  // 定义IAddInstrumentation方法
+  IAddInstrumentation: function (parameter1) {
+  }
+};
+
+//]]>
+
+</script>
 <title>必应词典</title>
 <meta http-equiv="content-type" content="text/html;charset=utf-8" />
 <meta name="generator" content="Geany 1.36" />
-<style type="text/css">html,body,h1,h2,h3,h4,h5,h6,p,img,ol,ul,li,form,table,tr,th,td,blockquote{border:0;border-collapse:collapse;border-spacing:0;list-style:none;margin:5;padding:0}client_def_hd_area{width:100%;overflow:hidden;margin-bottom:15px}.client_def_hd_hd_nw{display:inline-block}.client_def_hd_hd{margin-right:20px;float:left}.client_def_hd_pn_bar{overflow:hidden}.client_def_hd_pn_list{overflow:hidden;float:left;margin-right:10px}.client_def_hd_pn{float:left;margin:5px 5px 0 0;white-space:nowrap}.client_def_hd_hd{font-family:Microsoft YaHei;font-size:20px;color:#000;font-weight:bold}.client_def_hd_pn{font-family:Segoe UI,Arial,Helvetica,Sans-Serif;_font-family:Lucida Sans Unicode,sans-serif;font-size:13px;color:#777}.client_add_newword_f,.client_add_newword_o,.client_add_newword_d,.client_del_newword_f,.client_del_newword_o,.client_del_newword_d,.client_ktv_f,.client_ktv_o,.client_ktv_d,.client_aud_f,.client_aud_o,.client_aud_d,.client_share_f,.client_share_o,.client_share_d .client_copy_f,.client_copy_o,.client_copy_d{width:24px;height:24px;background-image:url("/th?id=OJ.VomR2COqzLF7sg&pid=MSNJVFeeds");background-repeat:no-repeat;_height:15px;_width:338px;_filter:progid:DXImageTransform.Microsoft.AlphaImageLoader(src="/th?id=OJ.VomR2COqzLF7sg&pid=MSNJVFeeds",sizingMethod="scale");_background:none;_background-color:#fff;_font-size:0}.client_do_you_mean_list_word,.client_siderbar_list_word,.client_word_change_word,.client_def_en_hover,.client_do_you_mean_word{color:#06a}.client_del_newword_o{_margin-left:-150px;background-position:-150px 0}.client_add_newword_o{_margin-left:-207px;background-position:-207px 0}.client_new_word{display:inline-block;float:left;margin-top:6px}.client_icon_container{width:16px;height:16px;overflow:hidden;cursor:pointer}.client_aud_o{_margin-left:-95px;background-position:-95px 0}.client_def_audio{margin-right:5px;float:left;margin-top:6px}.client_def_container{clear:both;overflow:hidden}.client_def_bar{margin-bottom:5px;clear:both;overflow:hidden}.client_def_title,.client_def_title_web{padding:1px 3px}.client_def_title_web{font-size:13px;background-color:#000;color:#fff;font-family:Segoe UI,Arial;font-weight:bold}.client_def_title{font-size:13px;background-color:#aaa;color:#fff;font-family:Segoe UI,Arial;font-weight:bold}.client_def_title_bar{width:45px;vertical-align:top;float:left}.client_def_list{margin-left:3px;overflow:hidden;_float:left}.client_def_list_item{overflow:hidden;display:block;_display:inline-block;padding-bottom:5px}.client_def_list_word_item{overflow:hidden;_float:left;padding-left:0}.client_def_list_word_bar{overflow:hidden;font-size:13px;color:#000;font-family:Microsoft YaHei,宋体}.client_def_list_word_content{float:left}.client_word_change{float:left;margin-right:10px}.client_word_change_def{overflow:hidden;margin-right:20px}.client_word_change_word{margin-right:10px;cursor:pointer;float:left}.client_word_change{font-size:13px;font-family:Microsoft YaHei,宋体;color:#777}</style>
+<style type="text/css">html,body,h1,h2,h3,h4,h5,h6,p,img,ol,ul,li,form,table,tr,th,td,blockquote{border:0;border-collapse:collapse;border-spacing:0;list-style:none;margin:5;padding:0}client_def_hd_area{width:100%;overflow:hidden;margin-bottom:15px}.client_def_hd_hd_nw{display:inline-block}.client_def_hd_hd{margin-right:20px;float:left}.client_def_hd_pn_bar{overflow:hidden}.client_def_hd_pn_list{overflow:hidden;float:left;margin-right:10px}.client_def_hd_pn{float:left;margin:5px 5px 0 0;white-space:nowrap}.client_def_hd_hd{font-family:Microsoft YaHei;font-size:20px;color:#000;font-weight:bold}.client_def_hd_pn{font-family:Segoe UI,Arial,Helvetica,Sans-Serif;_font-family:Lucida Sans Unicode,sans-serif;font-size:13px;color:#777}.client_add_newword_f,.client_add_newword_o,.client_add_newword_d,.client_del_newword_f,.client_del_newword_o,.client_del_newword_d,.client_ktv_f,.client_ktv_o,.client_ktv_d,.client_aud_f,.client_aud_o,.client_aud_d,.client_share_f,.client_share_o,.client_share_d .client_copy_f,.client_copy_o,.client_copy_d{width:24px;height:24px;background-image:url("https://cn.bing.com/rp/tRK3vTZmy6h8PLiWOFXtXDxmWME.png");background-repeat:no-repeat;_height:15px;_width:338px;_filter:progid:DXImageTransform.Microsoft.AlphaImageLoader(src="/th?id=OJ.VomR2COqzLF7sg&pid=MSNJVFeeds",sizingMethod="scale");_background:none;_background-color:#fff;_font-size:0}.client_do_you_mean_list_word,.client_siderbar_list_word,.client_word_change_word,.client_def_en_hover,.client_do_you_mean_word{color:#06a}.client_del_newword_o{_margin-left:-150px;background-position:-150px 0}.client_add_newword_o{_margin-left:-207px;background-position:-207px 0}.client_new_word{display:inline-block;float:left;margin-top:6px}.client_icon_container{width:16px;height:16px;overflow:hidden;cursor:pointer}.client_aud_o{_margin-left:-95px;background-position:-95px 0}.client_def_audio{margin-right:5px;float:left;margin-top:6px}.client_def_container{clear:both;overflow:hidden}.client_def_bar{margin-bottom:5px;clear:both;overflow:hidden}.client_def_title,.client_def_title_web{padding:1px 3px}.client_def_title_web{font-size:13px;background-color:#000;color:#fff;font-family:Segoe UI,Arial;font-weight:bold}.client_def_title{font-size:13px;background-color:#aaa;color:#fff;font-family:Segoe UI,Arial;font-weight:bold}.client_def_title_bar{width:45px;vertical-align:top;float:left}.client_def_list{margin-left:3px;overflow:hidden;_float:left}.client_def_list_item{overflow:hidden;display:block;_display:inline-block;padding-bottom:5px}.client_def_list_word_item{overflow:hidden;_float:left;padding-left:0}.client_def_list_word_bar{overflow:hidden;font-size:13px;color:#000;font-family:Microsoft YaHei,宋体}.client_def_list_word_content{float:left}.client_word_change{float:left;margin-right:10px}.client_word_change_def{overflow:hidden;margin-right:20px}.client_word_change_word{margin-right:10px;cursor:pointer;float:left}.client_word_change{font-size:13px;font-family:Microsoft YaHei,宋体;color:#777}</style>
 </head>
 <body> 
 {{content}}
@@ -40,7 +59,7 @@ def parse(gwords):
                "User-Agent": "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) \
                              Chrome/42.0.2311.90 Safari/537.36"
                }
-    # urlstr = 'https://cn.bing.com/dict/search?q=' + keyword
+    # urlstr = 'https://cn.bing.com/dict/search?q='
     urlstr = 'https://cn.bing.com/dict/clientsearch?mkt=zh-CN&setLang=zh&form=BDVEHC&ClientVer=BDDTV3.5.1.4320&q='
     url = quote(urlstr, safe=string.printable) + gwords
     try:


### PR DESCRIPTION
1,修复了音频的图标没有显示的bug
2,增加了基于htlm5的音频播放类ClientAudioPlayer，可以播放在线读音。

在测试过程中发现基于qt-webkit的goldendict无法正常播放读音，所有的网页词典也都无法正常发音，但在基于qt-webengine版本的goldendict可以。具体两个版本的差异可以参考https://bbs.archlinuxcn.org/viewtopic.php?id=12224
